### PR TITLE
Add YAML document start marker to generated ai-instructions.yml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,17 +114,18 @@ func SaveConfig(dir string, c *Config) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	var content []byte
+	content := []byte("---\n")
 	if len(c.Resolved) > 0 {
 		resolvedPart := configResolvedFields{Resolved: c.Resolved}
 		resolvedBytes, marshalErr := yaml.Marshal(resolvedPart)
 		if marshalErr != nil {
 			return fmt.Errorf("marshaling resolved: %w", marshalErr)
 		}
-		content = append(userBytes, []byte(resolvedSeparator)...)
+		content = append(content, userBytes...)
+		content = append(content, []byte(resolvedSeparator)...)
 		content = append(content, resolvedBytes...)
 	} else {
-		content = userBytes
+		content = append(content, userBytes...)
 	}
 
 	path := filepath.Join(dir, ConfigFile)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,6 +257,31 @@ func TestSaveConfigWithoutResolved(t *testing.T) {
 	}
 }
 
+func TestSaveConfigHasDocumentStart(t *testing.T) {
+	dir := t.TempDir()
+
+	original := &Config{
+		Version: 1,
+		Registry: RegistryConfig{
+			URL: "https://ai-ctx.example.com",
+		},
+		Stacks: []string{"php"},
+	}
+
+	if err := SaveConfig(dir, original); err != nil {
+		t.Fatalf("SaveConfig() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ConfigFile))
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	if !strings.HasPrefix(string(data), "---\n") {
+		t.Error("config should start with YAML document start marker '---'")
+	}
+}
+
 func TestSaveConfigHasCommentSeparator(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Prevents yamllint document-start warning by prefixing the output with "---".